### PR TITLE
fix: just nano

### DIFF
--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -13,7 +13,7 @@ import determineOutcome from '../helpers/determineOutcome';
 
 const calculateDuration = (startTime: bigint): number => {
   const endTime: bigint = process.hrtime.bigint();
-  return Number((Number(endTime - startTime) / 1000000).toFixed(3));
+  return Number(endTime - startTime);
 };
 
 export const execute = async (reqObj: unknown): Promise<void> => {


### PR DESCRIPTION
return nano seconds only to the field
Related to https://github.com/frmscoe/General-Issues/issues/67 as (BUG FIX)
Gist: after finding out that the milliseconds would be ununiform with the precision of decimals we decided to just use nanoseconds