### PR TITLE
Remove `reason` field from rules' happy path

### DIFF
--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -132,6 +132,7 @@ export const execute = async (reqObj: unknown): Promise<void> => {
   const spanResponse = apm.startSpan(`send.to.typroc.${ruleRes.id}`);
   try {
     request.metaData.traceParent = apm.getCurrentTraceparent();
+    // happy path, we don't need reason
     delete ruleRes.reason;
     await server.handleResponse({
       ...request,

--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -132,6 +132,7 @@ export const execute = async (reqObj: unknown): Promise<void> => {
   const spanResponse = apm.startSpan(`send.to.typroc.${ruleRes.id}`);
   try {
     request.metaData.traceParent = apm.getCurrentTraceparent();
+    delete ruleRes.reason;
     await server.handleResponse({
       ...request,
       ruleResult: ruleRes,


### PR DESCRIPTION
We need to explicitly remove the reason field since the rule returns an object with that property. This makes it so we can prune that field from one place (here), rather than removing it on every rule.