### PR TITLE
fix: explicit check if .err before removing reason

### DIFF
--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -155,8 +155,10 @@ export const execute = async (reqObj: unknown): Promise<void> => {
   const spanResponse = apm.startSpan(`send.to.typroc.${ruleRes.id}`);
   try {
     request.metaData.traceParent = apm.getCurrentTraceparent();
-    // happy path, we don't need reason
-    delete ruleRes.reason;
+    if (ruleRes.subRuleRef !== '.err') {
+      // happy path, we don't need reason
+      delete ruleRes.reason;
+    }
     await server.handleResponse({
       ...request,
       ruleResult: ruleRes,


### PR DESCRIPTION
Related to: https://github.com/frmscoe/rule-executer/issues/88