### PR TITLE
fix: update STARTUP_TYPE default to 'nats'

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,7 +40,7 @@ REDIS_SERVERS='[{"host":"127.0.0.1", "port":6379}, {"host":"127.0.0.1", "port":6
 REDIS_IS_CLUSTER=false
 
 # Nats config
-STARTUP_TYPE=jetstream
+STARTUP_TYPE=nats
 SERVER_URL=0.0.0.0:4222
 PRODUCER_STREAM=RuleResponseRule-xxx
 CONSUMER_STREAM=RuleRequest


### PR DESCRIPTION
Updated .env.template:

STARTUP_TYPE to nats

Tested as per environment setup guide:
https://github.com/frmscoe/docs/blob/main/Community/Tazama-Contribution-Guide.md#32-setting-up-the-development-environment