### PR TITLE
chore - bump rule-901 package version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dotenv": "^16.3.2",
         "log4js": "^6.9.1",
         "node-cache": "^5.1.2",
-        "rule": "npm:@frmscoe/rule-901@^1.0.7",
+        "rule": "npm:@frmscoe/rule-901@^1.1.0",
         "tslib": "^2.6.0"
       },
       "devDependencies": {
@@ -8042,9 +8042,9 @@
     },
     "node_modules/rule": {
       "name": "@frmscoe/rule-901",
-      "version": "1.0.7",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/rule-901/1.0.7/613387d0141bf52b640dda44e4d38a4798949b8e",
-      "integrity": "sha512-B7phtOnXGyNH0E2KO5pBenbOqiI3LZcXMDVnZC2V0Y6ZEaN6L5+O6B2/VV1LDDFfkZeAkeznxR8TllmJlNSpSw==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/rule-901/1.1.0/84d0e170c7e9164eea4f5d3d157af9fc9f1c867f",
+      "integrity": "sha512-ZDMGMZjH6rEU7eEUl6xaqQyX9MRNn5hDYgxYJUQSmGc6KDC20L5MVm2PqVO5d4Dka//RFCwCGQUfRpg7/y99BA==",
       "dependencies": {
         "@frmscoe/frms-coe-lib": "^3.0.0",
         "ts-node": "^10.9.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dotenv": "^16.3.2",
     "log4js": "^6.9.1",
     "node-cache": "^5.1.2",
-    "rule": "npm:@frmscoe/rule-901@^1.0.7",
+    "rule": "npm:@frmscoe/rule-901@^1.1.0",
     "tslib": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Rule 901's package version was bumped to v1.1.0 to reflect the latest changes to update the rule processor. The package version reference in the `package.json` file in the rule executer must also be updated.