### PR TITLE
build: revert to explicit versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "keywords": [],
   "license": "Apache-2.0",
   "dependencies": {
-    "@frmscoe/frms-coe-lib": "next",
-    "@frmscoe/frms-coe-startup-lib": "next",
+    "@frmscoe/frms-coe-lib": "4.0.0-rc.11",
+    "@frmscoe/frms-coe-startup-lib": "2.2.0-rc.4",
     "dotenv": "^16.4.5",
     "node-cache": "^5.1.2",
-    "rule": "npm:@frmscoe/rule-901@next",
+    "rule": "npm:@frmscoe/rule-901@2.0.0-rc.1",
     "tslib": "^2.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

 - Reinstated explicit versions for internal dependencies

## Why are we doing this?

 - GitHub does not support @next as a package tag

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
