### PR TITLE
build: Version bump of coe-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@frmscoe/frms-coe-lib": "^4.0.0-rc.10",
-        "@frmscoe/frms-coe-startup-lib": "^2.2.0-rc.3",
+        "@frmscoe/frms-coe-lib": "4.0.0-rc.12",
+        "@frmscoe/frms-coe-startup-lib": "2.2.0-rc.4",
         "dotenv": "^16.4.5",
         "node-cache": "^5.1.2",
         "rule": "npm:@frmscoe/rule-901@2.0.0-rc.1",
@@ -840,9 +840,10 @@
       }
     },
     "node_modules/@frmscoe/frms-coe-lib": {
-      "version": "4.0.0-rc.10",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.10/243fd9e34c910718b533ffc93857034f7bf18f48",
-      "integrity": "sha512-8UOOhyqoOWnA500uImBHK5zMlj+ro9RtJtCgSNsAOT6BPHhTguPRU8jaImxRtHM5FsblNBfxsTrx6J5FUm1q1A==",
+      "version": "4.0.0-rc.12",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.12/b759369fd7d6f824ebab2b65e837c6ed0892792f",
+      "integrity": "sha512-TwRb/IgFMM3UzYraHgRoEdkFyzoSl1z642o8XIouCoThsHMP4zedeB8xHSz9l5XJPUE9OtJ4fiJPSME6tI4UHw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
         "@grpc/grpc-js": "^1.10.9",
@@ -861,9 +862,10 @@
       }
     },
     "node_modules/@frmscoe/frms-coe-startup-lib": {
-      "version": "2.2.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-startup-lib/2.2.0-rc.3/11505ec73b76794152ae639ce55b5a692c1ddc9c",
-      "integrity": "sha512-aDPwtNV7+DByvih4tr9a7h1UEAlEKSqFVkOCXSKZpGw8G0yNJXTnz4SNLK5odW2IwcFNPnX/BBIffCnBs6txXw==",
+      "version": "2.2.0-rc.4",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-startup-lib/2.2.0-rc.4/ca2d9520340eea41134b0dd4bb120ab93096434b",
+      "integrity": "sha512-nO8w7P9+4hNPhPf+Apa6GsxT59ZjCN3ptyPNQX78pbmDL5SG5eFMx4S+qlO7DiDJFwTeaFVfRR9j5x4CpX2iGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@frmscoe/frms-coe-lib": "^4.0.0-rc.7",
         "nats": "^2.14.0"
@@ -7520,6 +7522,28 @@
       "dependencies": {
         "@frmscoe/frms-coe-lib": "4.0.0-rc.10",
         "ts-node": "^10.9.2"
+      }
+    },
+    "node_modules/rule/node_modules/@frmscoe/frms-coe-lib": {
+      "version": "4.0.0-rc.10",
+      "resolved": "https://npm.pkg.github.com/download/@frmscoe/frms-coe-lib/4.0.0-rc.10/243fd9e34c910718b533ffc93857034f7bf18f48",
+      "integrity": "sha512-8UOOhyqoOWnA500uImBHK5zMlj+ro9RtJtCgSNsAOT6BPHhTguPRU8jaImxRtHM5FsblNBfxsTrx6J5FUm1q1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/uuid": "^9.0.8",
+        "arangojs": "^8.8.1",
+        "dotenv": "^16.4.5",
+        "elastic-apm-node": "^4.6.0",
+        "fast-json-stringify": "^5.16.0",
+        "ioredis": "^5.4.1",
+        "node-cache": "^5.1.2",
+        "pino": "^9.2.0",
+        "pino-elasticsearch": "^8.0.0",
+        "protobufjs": "^7.3.2",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "keywords": [],
   "license": "Apache-2.0",
   "dependencies": {
-    "@frmscoe/frms-coe-lib": "4.0.0-rc.11",
+    "@frmscoe/frms-coe-lib": "4.0.0-rc.12",
     "@frmscoe/frms-coe-startup-lib": "2.2.0-rc.4",
     "dotenv": "^16.4.5",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Updated Library Version

## Why are we doing this?

Library has an issue accessing the grpc sidecar from the current lib version

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [ ] Unit tests passing and Documentation done
