### PR TITLE
fix: refactor dependabot.yml to only dev target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,17 +20,6 @@ updates:
     registries:
       - github
 
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "main"
-    allow:
-      - dependency-name: "@tazama-lf/frms-coe-lib"
-      - dependency-name: "@tazama-lf/frms-coe-startup-lib"
-    registries:
-      - github
-
 registries:
   github:
     type: "npm-registry"


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Remove main from PR target

## Why are we doing this?
Was asked to only target this branch on dev with valid reasons.

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
