### PR TITLE
build: add rule-902 event trigger build for rc image build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# Please do not attempt to edit this file without the direct consent from the DevOps team. This file is managed centrally.
-# Contact @scott45
-
-* @Justus-at-Tazama @Sandy-at-Tazama
-/.github/ @scott45
+* @Justus-at-Tazama @Sandy-at-Tazama @scott45

--- a/.github/workflows/trigger-rules-901-and-902.yml
+++ b/.github/workflows/trigger-rules-901-and-902.yml
@@ -1,4 +1,4 @@
-name: Trigger Rule 901 Workflow
+name: Trigger Rule 901 and 902 Workflows
 
 on:
   push:
@@ -14,3 +14,9 @@ jobs:
           token: ${{ secrets.GH_TOKEN_LIB }}  # PAT with repo scope
           repository: tazama-lf/rule-901
           event-type: rule-executer-update  # Custom event type
+      - name: Dispatch to Rule 902
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_TOKEN_LIB }} # Same PAT
+          repository: tazama-lf/rule-902
+          event-type: rule-executer-update # Same event type


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
- Add rule-902 event trigger build for rc image build
- Change code owners

## Why are we doing this?
- Automate 902 deployment when rule-executer code changes
- Have code owners functionality working 

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
