### PR TITLE
build: test 901 and 902 rc image builds after rule executer is updated

### DIFF
--- a/.github/workflows/trigger-rules-901-and-902.yml
+++ b/.github/workflows/trigger-rules-901-and-902.yml
@@ -1,4 +1,4 @@
-name: Trigger Rule 901 and 902 Workflows
+name: Trigger Rule 901 and 902 Workflows after rule executer repo is updated
 
 on:
   push:


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Test 901 and 902 rc image builds after rule executer is updated

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
