### PR TITLE
feat: implemented JSON schema validation for rule configs

### DIFF
--- a/__tests__/unit/getRuleConfigSchema.test.ts
+++ b/__tests__/unit/getRuleConfigSchema.test.ts
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('rule/lib', () => ({
+  handleTransaction: jest.fn(),
+  getRuleConfigSchema: jest.fn(),
+}));
+
+import { NetworkMap, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { DataCacheSample, Pacs002Sample } from '@tazama-lf/frms-coe-lib/lib/tests/data';
+import { handleTransaction, getRuleConfigSchema } from 'rule/lib';
+import { configuration, databaseManager, initializeDB, runServer, server } from '../../src';
+import { execute } from '../../src/controllers/execute';
+import determineOutcome from '../../src/helpers/determineOutcome';
+import Ajv from 'ajv';
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/services/dbManager', () => ({
+  CreateStorageManager: jest
+    .fn()
+    .mockReturnValue({ db: { getRuleConfig: jest.fn(), isReadyCheck: jest.fn().mockReturnValue({ nodeEnv: 'test' }) } }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/config/processor.config', () => ({
+  validateProcessorConfig: jest.fn().mockReturnValue({ functionName: 'test-rule-executor', nodeEnv: 'test', maxCPU: 1 }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-startup-lib/lib/interfaces/iStartupConfig', () => ({
+  startupConfig: {
+    startupType: 'nats',
+    consumerStreamName: 'consumer',
+    serverUrl: 'server',
+    producerStreamName: 'producer',
+    functionName: 'producer',
+  },
+}));
+
+const NetworkMapSample: NetworkMap[] = [
+  {
+    active: true,
+    tenantId: 'tenantId',
+    cfg: '1.0.0',
+    messages: [
+      {
+        id: '004@1.0.0',
+        cfg: '1.0.0',
+        txTp: 'pacs.002.001.12',
+        typologies: [
+          {
+            id: 'typology-processor@1.0.0',
+            tenantId: 'tenantId',
+            cfg: '999@1.0.0',
+            rules: [
+              {
+                id: 'EFRuP@1.0.0',
+                cfg: 'none',
+              },
+              {
+                id: '901@1.0.0',
+                cfg: '1.0.0',
+              },
+              {
+                id: '902@1.0.0',
+                cfg: '1.0.0',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const ruleConfig: RuleConfig = {
+  id: '901@1.0.0',
+  cfg: '1.0.0',
+  tenantId: 'tenantId',
+  desc: 'Number of outgoing transactions - debtor',
+  config: {
+    parameters: {
+      maxQueryRange: 86400000,
+    },
+    exitConditions: [
+      {
+        subRuleRef: '.x00',
+        reason: 'Incoming transaction is unsuccessful',
+      },
+    ],
+    bands: [
+      {
+        subRuleRef: '.01',
+        upperLimit: 2,
+        reason: 'The debtor has performed one transaction to date',
+      },
+      {
+        subRuleRef: '.02',
+        lowerLimit: 2,
+        upperLimit: 3,
+        reason: 'The debtor has performed two transactions to date',
+      },
+      {
+        subRuleRef: '.03',
+        lowerLimit: 3,
+        reason: 'The debtor has performed three or more transactions to date',
+      },
+    ],
+  },
+};
+
+const ruleRes: RuleResult = {
+  id: '901@1.0.0',
+  cfg: '1.0.0',
+  tenantId: 'tenantId',
+  subRuleRef: '.01',
+  prcgTm: undefined,
+  reason: undefined,
+  indpdntVarbl: 1,
+};
+
+const getMockRequest = () => {
+  const quote: RuleRequest = {
+    transaction: Object.assign({}, Pacs002Sample),
+    networkMap: NetworkMapSample[0],
+    DataCache: Object.assign({}, DataCacheSample),
+  };
+  return quote;
+};
+
+const ajv = new Ajv(); // Initialize Ajv
+const rule901Schema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+    },
+    cfg: {
+      type: 'string',
+    },
+    config: {
+      type: 'object',
+      properties: {
+        parameters: {
+          type: 'object',
+          properties: {
+            maxQueryRange: {
+              type: 'integer',
+            },
+          },
+          required: ['maxQueryRange'],
+        },
+        exitConditions: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 1,
+          items: {
+            type: 'object',
+            properties: {
+              subRuleRef: {
+                type: 'string',
+                enum: ['.x00'],
+              },
+              reason: {
+                type: 'string',
+                enum: ['Incoming transaction is unsuccessful'],
+              },
+            },
+            required: ['subRuleRef', 'reason'],
+            additionalProperties: false,
+          },
+        },
+        bands: {
+          type: 'array',
+          minItems: 2,
+          items: {
+            type: 'object',
+            properties: {
+              subRuleRef: {
+                type: 'string',
+              },
+              upperLimit: {
+                type: 'integer',
+              },
+              lowerLimit: {
+                type: 'integer',
+              },
+              reason: {
+                type: 'string',
+              },
+            },
+            required: ['subRuleRef', 'reason'],
+            additionalProperties: false,
+            anyOf: [
+              {
+                required: ['upperLimit'],
+              },
+              {
+                required: ['lowerLimit'],
+              },
+            ],
+          },
+        },
+      },
+      required: ['parameters', 'exitConditions', 'bands'],
+    },
+    tenantId: {
+      type: 'string',
+    },
+    desc: {
+      type: 'string',
+    },
+  },
+  required: ['id', 'cfg', 'config', 'tenantId'],
+};
+const validate = ajv.compile(rule901Schema);
+
+beforeAll(async () => {
+  await initializeDB();
+  await runServer();
+});
+
+afterAll((done) => {
+  done();
+});
+
+describe('AJV Schema Validation', () => {
+  let responseSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configuration.RULE_NAME = '901';
+    configuration.RULE_VERSION = '1.0.0';
+  });
+
+  it('should return true for valid data', () => {
+    const validData = ruleConfig;
+    expect(validate(validData)).toBe(true);
+    expect(validate.errors).toBeNull(); // No errors for valid data
+  });
+
+  it('should pass schema validation with valid config', async () => {
+    jest.spyOn(require('rule/lib'), 'getRuleConfigSchema').mockReturnValue(rule901Schema);
+
+    jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<RuleConfig> => {
+      return await Promise.resolve(ruleConfig);
+    });
+
+    jest.spyOn(require('rule/lib'), 'handleTransaction').mockResolvedValue(ruleRes);
+
+    const expectedReq = getMockRequest();
+    responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+    await execute(expectedReq);
+
+    expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+  });
+
+  it('should respond with error when schema validation fails', async () => {
+    jest.spyOn(require('rule/lib'), 'getRuleConfigSchema').mockReturnValue(rule901Schema);
+
+    const { id, ...invalidRuleConfig } = ruleConfig;
+
+    jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<any> => {
+      return await Promise.resolve(invalidRuleConfig); // This will fail validation
+    });
+
+    const errRuleResult: RuleResult = {
+      ...ruleRes,
+      subRuleRef: '.err',
+      indpdntVarbl: 0,
+      prcgTm: expect.any(Number), // Accepts any number
+      reason: "Rule configuration validation failed: data must have required property 'id'",
+    };
+
+    const expectedReq = getMockRequest();
+    responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+    await execute(expectedReq);
+
+    expect(responseSpy).toHaveBeenCalledWith({
+      transaction: expectedReq.transaction,
+      ruleResult: expect.objectContaining(errRuleResult),
+      networkMap: expectedReq.networkMap,
+    });
+  });
+
+  it('should handle error when getRuleConfigSchema is not available', async () => {
+    jest.spyOn(require('rule/lib'), 'getRuleConfigSchema').mockImplementation(() => {
+      throw new Error('getRuleConfigSchema is not a function');
+    });
+
+    jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<RuleConfig> => {
+      return await Promise.resolve(ruleConfig);
+    });
+
+    jest.spyOn(require('rule/lib'), 'handleTransaction').mockResolvedValue(ruleRes);
+
+    const expectedReq = getMockRequest();
+    responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+    await execute(expectedReq);
+
+    expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+  });
+
+  it('should skip schema validation when getRuleConfigSchema is not a function', async () => {
+    Object.defineProperty(require('rule/lib'), 'getRuleConfigSchema', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<RuleConfig> => {
+      return await Promise.resolve(ruleConfig);
+    });
+
+    jest.spyOn(require('rule/lib'), 'handleTransaction').mockResolvedValue(ruleRes);
+
+    const expectedReq = getMockRequest();
+    responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+    await execute(expectedReq);
+
+    expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+  });
+});

--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -64,6 +64,7 @@ const getMockRequest = () => {
     transaction: Object.assign({}, Pacs002Sample),
     networkMap: NetworkMapSample[0],
     DataCache: Object.assign({}, DataCacheSample),
+    metaData: { prcgTmDp: 999, prcgTmED: 999, traceParent: 'some-initial-trace' },
   };
   return quote;
 };
@@ -93,6 +94,7 @@ describe('Logic Service', () => {
   });
 
   describe('execute', () => {
+    jest.spyOn(require('rule/lib'), 'getRuleConfigSchema').mockImplementation(() => undefined);
     it('should respond with rule result of true for happy path ', async () => {
       jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<RuleConfig> => {
         const rc: RuleConfig = { ...ruleConfig };
@@ -100,12 +102,13 @@ describe('Logic Service', () => {
       });
 
       const expectedReq = getMockRequest();
+      expectedReq.metaData = { prcgTmDp: 999, prcgTmED: 999, traceParent: 'some-initial-trace' };
 
       responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
 
       await execute(expectedReq);
 
-      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: expect.any(Object), ruleResult: ruleRes });
     });
 
     it('should respond with rule result - ruleConfig - exitConditions are undefined ', async () => {
@@ -120,7 +123,7 @@ describe('Logic Service', () => {
 
       await execute(expectedReq);
 
-      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: expect.any(Object), ruleResult: ruleRes });
     });
 
     it('should respond with rule result - ruleConfig - bands are undefined ', async () => {
@@ -135,7 +138,7 @@ describe('Logic Service', () => {
 
       await execute(expectedReq);
 
-      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: undefined, ruleResult: ruleRes });
+      expect(responseSpy).toHaveBeenCalledWith({ ...expectedReq, metaData: expect.any(Object), ruleResult: ruleRes });
     });
 
     it('should respond with rule result .err - ruleConfig: config is undefined ', async () => {
@@ -187,7 +190,7 @@ describe('Logic Service', () => {
       const errRuleResult: RuleResult = {
         ...ruleRes,
         subRuleRef: '.err',
-        reason: 'Rule not found in network map',
+        reason: 'Rule configuration version not found in network map',
         indpdntVarbl: ruleRes.indpdntVarbl,
       };
 
@@ -283,6 +286,38 @@ describe('Logic Service', () => {
       await execute(expectedReq);
 
       expect(responseSpy).toThrow();
+    });
+  });
+
+  describe('database errors', () => {
+    it('should respond with rule result .err - database connection error', async () => {
+      jest.spyOn(databaseManager, 'getRuleConfig').mockRejectedValueOnce(new Error('Database connection timeout'));
+
+      const errRuleResult: RuleResult = {
+        ...ruleRes,
+        subRuleRef: '.err',
+        reason: 'Database connection timeout',
+        indpdntVarbl: 0,
+      };
+
+      const expectedReq = getMockRequest();
+      responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+      await execute(expectedReq);
+
+      expect(responseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transaction: expectedReq.transaction,
+          networkMap: expectedReq.networkMap,
+          ruleResult: expect.objectContaining({
+            cfg: '1.0',
+            id: '003@1.0',
+            subRuleRef: errRuleResult.subRuleRef,
+            reason: errRuleResult.reason,
+            indpdntVarbl: errRuleResult.indpdntVarbl,
+          }),
+        }),
+      );
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11",
         "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.6",
+        "ajv": "^8.17.1",
         "dotenv": "^17.2.1",
         "node-cache": "^5.1.2",
-        "rule": "npm:@tazama-lf/rule-901@3.0.0-rc.6",
+        "rule": "npm:@tazama-lf/rule-901@3.1.0-rc.1",
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1"
       },
@@ -81,7 +82,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -774,13 +774,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -862,6 +862,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -872,6 +889,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -887,9 +911,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -900,9 +924,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1920,7 +1944,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1980,6 +2003,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2104,14 +2133,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
-      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/types": "^8.46.1",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -2398,11 +2427,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -2549,7 +2577,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3029,7 +3056,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3096,16 +3122,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3592,9 +3617,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
-      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+      "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3693,7 +3718,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3842,9 +3866,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001750",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "dev": true,
       "funding": [
         {
@@ -4086,9 +4110,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4489,9 +4513,9 @@
       }
     },
     "node_modules/elastic-apm-node": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.14.0.tgz",
-      "integrity": "sha512-SiA34EevGg1P9tCXca1BydVhNX1H++rHW9QXdQSasMr3+3eRtTx5qnGL4SRm5CRy55yFMmajeZJXafqgHTrOYw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.15.0.tgz",
+      "integrity": "sha512-8N176AlRizpX+JcNP3xPPbl9HjiDG6PRTIY0XfY2SSmI7dAvxlYk/TFBcOXeGpoMTYCHZHNPUUL0ryvaMV7EGA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -4512,7 +4536,7 @@
         "fast-safe-stringify": "^2.0.7",
         "fast-stream-to-buffer": "^1.0.0",
         "http-headers": "^3.0.2",
-        "import-in-the-middle": "1.14.2",
+        "import-in-the-middle": "1.14.4",
         "json-bigint": "^1.0.0",
         "lru-cache": "10.2.0",
         "measured-reporting": "^1.51.1",
@@ -4524,7 +4548,7 @@
         "pino": "^8.15.0",
         "readable-stream": "^3.6.2",
         "relative-microtime": "^2.0.0",
-        "require-in-the-middle": "^7.1.1",
+        "require-in-the-middle": "^8.0.0",
         "semver": "^7.5.4",
         "shallow-clone-shim": "^2.0.0",
         "source-map": "^0.8.0-beta.0",
@@ -4872,26 +4896,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
         "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
+        "@eslint/js": "9.38.0",
         "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -5260,6 +5282,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5270,6 +5309,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -5456,7 +5502,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5527,6 +5572,22 @@
         "end-of-stream": "^1.4.1"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -5571,7 +5632,6 @@
       "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.9",
         "sprintf-js": "^1.1.1",
@@ -5894,9 +5954,9 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.1.tgz",
+      "integrity": "sha512-dTCcAe9fRQf06ELwel6lWWFrEbstwjUBYEhr5VRGoC+iPDZQucHppCowaIp8b8v92tU1G4X4H3b/Y6zXZxkMsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -6154,15 +6214,15 @@
       "license": "MIT"
     },
     "node_modules/google-auth-library": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.0.tgz",
-      "integrity": "sha512-CmIrSy1bqMQUsPmA9+hcSbAXL80cFhu40cGMUjCaLpNKVzzvi+0uAHq8GNZxkoGYIsTX4ZQ7e4aInAqWxgn4fg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.1.tgz",
+      "integrity": "sha512-VlvZ+QDWng3aPh++0BSQlSJyjn4qgLLTmqylAR3as0dr6YwPkZpHcZAngAFr68TDVCUSQVRTkV73K/D3m7vEIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "gaxios": "^7.0.0",
-        "gcp-metadata": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
         "google-logging-utils": "^1.0.0",
         "gtoken": "^8.0.0",
         "jws": "^4.0.0"
@@ -6567,9 +6627,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-      "integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -6646,7 +6706,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
       "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.4.0",
         "cluster-key-slot": "^1.1.0",
@@ -6782,6 +6841,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7257,7 +7317,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7904,10 +7963,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8656,9 +8714,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
+      "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9032,6 +9090,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -9069,7 +9128,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9188,11 +9246,12 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
-      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
@@ -9201,7 +9260,6 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -9697,18 +9755,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
+      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/requires-port": {
@@ -9721,6 +9787,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -9855,9 +9922,9 @@
     },
     "node_modules/rule": {
       "name": "@tazama-lf/rule-901",
-      "version": "3.0.0-rc.6",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/rule-901/3.0.0-rc.6/8166f45d5413e1406665b625867684acad54c425",
-      "integrity": "sha512-MZiZCQXBFOJDr1sLQvE+tLsqpwhChX+o627DmCZBeuzGCbRtyFY294+NRJ2gFSEZtodcKXYCMXa79Is5+XVnDQ==",
+      "version": "3.1.0-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/rule-901/3.1.0-rc.1/20f804031f0301c745c464e2d167139277c2ed41",
+      "integrity": "sha512-XO3VGUOB/5izQNisOsgbj1EScS1mrPKUL208aXF2Aj4R3ADEj5VFwcg5BG/DCO7MF71uXmCd6bQy/Vxbn3aiqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11"
@@ -10190,12 +10257,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/slow-redact": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
-      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
-      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
@@ -10694,6 +10755,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11036,7 +11098,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11242,7 +11303,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --project tsconfig.json",
     "start": "node -r dotenv/config build/index.js",
     "clean": "npx rimraf build node_modules coverage package-lock.json",
+    "reset": "npm run clean & npm i",
     "fix": "npm run fix:prettier && npm run fix:eslint",
     "fix:eslint": "eslint --fix",
     "fix:prettier": "prettier --write \"**/*.ts\"",
@@ -27,9 +28,10 @@
   "dependencies": {
     "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11",
     "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.6",
+    "ajv": "^8.17.1",
     "dotenv": "^17.2.1",
     "node-cache": "^5.1.2",
-    "rule": "npm:@tazama-lf/rule-901@3.0.0-rc.6",
+    "rule": "npm:@tazama-lf/rule-901@3.1.0-rc.1",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1"
   },

--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import apm from '../apm';
+import Ajv from 'ajv';
 import type { RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import type { MetaData } from '@tazama-lf/frms-coe-lib/lib/interfaces/metaData';
 import * as util from 'node:util';
-import { handleTransaction } from 'rule/lib';
+import { handleTransaction, getRuleConfigSchema } from 'rule/lib';
 import { databaseManager, loggerService, server } from '..';
 import { configuration } from '../';
 import determineOutcome from '../helpers/determineOutcome';
@@ -73,11 +74,41 @@ export const execute = async (reqObj: unknown): Promise<void> => {
   let ruleConfig: RuleConfig | undefined;
   const spanRuleConfig = apm.startSpan(`db.get.ruleconfig.${ruleRes.id}`);
   try {
-    if (!ruleRes.cfg) throw new Error('Rule not found in network map');
+    if (!ruleRes.cfg) throw new Error('Rule configuration version not found in network map');
     ruleConfig = await databaseManager.getRuleConfig(ruleRes.id, ruleRes.cfg, request.transaction.TenantId);
     spanRuleConfig?.end();
     if (!ruleConfig?.config) {
       throw new Error('Rule processor configuration not retrievable');
+    }
+
+    if (typeof getRuleConfigSchema === 'function') {
+      try {
+        const schema = getRuleConfigSchema();
+        const ajv = new Ajv();
+        const validate = ajv.compile(schema); // Only catch compilation errors
+
+        const isValid = validate(ruleConfig); // Don't catch validation failures
+        if (!isValid) {
+          throw new Error(`Rule configuration validation failed: ${ajv.errorsText(validate.errors)}`);
+        }
+        loggerService.log('Rule configuration schema validation passed', context, configuration.functionName);
+      } catch (schemaError) {
+        // Only catch if it's a schema compilation error, not validation failure
+        if ((schemaError as Error).message.includes('Rule configuration validation failed')) {
+          throw schemaError; // Re-throw validation failures
+        }
+        loggerService.log(
+          `Schema validation skipped - invalid schema: ${(schemaError as Error).message}`,
+          context,
+          configuration.functionName,
+        );
+      }
+    } else {
+      loggerService.log(
+        'Schema validation skipped - getRuleConfigSchema not available in rule package',
+        context,
+        configuration.functionName,
+      );
     }
   } catch (error) {
     spanRuleConfig?.end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true /* Include modules imported with '.json' extension */,
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "moduleResolution": "nodenext",
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "isolatedModules": true /* Allow hybrid module kind (Node16/18/Next) */
   },
   "include": ["./src/**/*"],
   "exclude": [


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Fetches a rule's config schema via its exposed getRuleConfigSchema() function (if it exists).
Added validation for rule config retrieved from the database against the rule's JSON schema via AJV.
Added unit tests.

## Why are we doing this?

Drive rule configuration validation via a JSON schema to obviate unnecessary and inconsistent rule config validation in rule processors, the rule-executer and the determineOutcome function.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
