### PR TITLE
fix(deps): update library to use correct cache key for getRuleConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "3.0.0-postgres.alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11",
+        "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.13",
         "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.6",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.2.3",
         "node-cache": "^5.1.2",
         "rule": "npm:@tazama-lf/rule-901@3.0.0-rc.6",
         "ts-node": "^10.9.2",
@@ -19,21 +19,21 @@
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-        "@stylistic/eslint-plugin": "^5.3.1",
+        "@stylistic/eslint-plugin": "^5.5.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.3.0",
-        "@typescript-eslint/eslint-plugin": "^8.42.0",
-        "@typescript-eslint/parser": "^8.42.0",
-        "eslint": "^9.34.0",
+        "@typescript-eslint/eslint-plugin": "^8.46.1",
+        "@typescript-eslint/parser": "^8.46.1",
+        "eslint": "^9.38.0",
         "eslint-config-love": "^122.0.0",
         "eslint-config-prettier": "^10.1.8",
         "husky": "9.1.7",
-        "ioredis-mock": "^8.9.0",
-        "jest": "^30.1.2",
-        "lint-staged": "^16.1.6",
+        "ioredis-mock": "8.9.0",
+        "jest": "^30.2.0",
+        "lint-staged": "^16.2.4",
         "prettier": "^3.6.2",
-        "ts-jest": "^29.4.1",
-        "typescript": "^5.8.3"
+        "ts-jest": "^29.4.5",
+        "typescript": "~5.8.3"
       }
     },
     "node_modules/@acuminous/bitsyntax": {
@@ -81,7 +81,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -774,13 +773,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -813,9 +812,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -887,9 +886,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -900,9 +899,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1920,7 +1919,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1980,6 +1978,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2104,14 +2108,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
-      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/types": "^8.46.1",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -2134,9 +2138,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "6.0.0-postgres.alpha.11",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-postgres.alpha.11/874068342144bced91b445690f929b2fec3ae583",
-      "integrity": "sha512-lEVPcnHqwGXmTQUZhUZTKOZTxvWfW9iAHUUqnPZ5Gy7Z71nzvBcGpyADR2IkLD/12wKXDHbwPhSgQkwUM5pjlw==",
+      "version": "6.0.0-postgres.alpha.13",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-postgres.alpha.13/db04627ff5a7f7717c57f6214cea1fd84b812954",
+      "integrity": "sha512-n2iZ7RHVePU2TcUmIdS0CrYc6TaODSorJCMW/ltyocwERQiIl4ppT5AUQ+i5tfGeRTK30n/UaV8MUI7mfbrQpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2398,11 +2402,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -2549,7 +2552,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3029,7 +3031,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3592,9 +3593,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
-      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+      "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3693,7 +3694,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3842,9 +3842,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001750",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "dev": true,
       "funding": [
         {
@@ -4086,9 +4086,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4489,9 +4489,9 @@
       }
     },
     "node_modules/elastic-apm-node": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.14.0.tgz",
-      "integrity": "sha512-SiA34EevGg1P9tCXca1BydVhNX1H++rHW9QXdQSasMr3+3eRtTx5qnGL4SRm5CRy55yFMmajeZJXafqgHTrOYw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.15.0.tgz",
+      "integrity": "sha512-8N176AlRizpX+JcNP3xPPbl9HjiDG6PRTIY0XfY2SSmI7dAvxlYk/TFBcOXeGpoMTYCHZHNPUUL0ryvaMV7EGA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -4512,7 +4512,7 @@
         "fast-safe-stringify": "^2.0.7",
         "fast-stream-to-buffer": "^1.0.0",
         "http-headers": "^3.0.2",
-        "import-in-the-middle": "1.14.2",
+        "import-in-the-middle": "1.14.4",
         "json-bigint": "^1.0.0",
         "lru-cache": "10.2.0",
         "measured-reporting": "^1.51.1",
@@ -4524,7 +4524,7 @@
         "pino": "^8.15.0",
         "readable-stream": "^3.6.2",
         "relative-microtime": "^2.0.0",
-        "require-in-the-middle": "^7.1.1",
+        "require-in-the-middle": "^8.0.0",
         "semver": "^7.5.4",
         "shallow-clone-shim": "^2.0.0",
         "source-map": "^0.8.0-beta.0",
@@ -4872,26 +4872,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
         "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
+        "@eslint/js": "9.38.0",
         "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -5571,7 +5569,6 @@
       "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.9",
         "sprintf-js": "^1.1.1",
@@ -5894,9 +5891,9 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.1.tgz",
+      "integrity": "sha512-dTCcAe9fRQf06ELwel6lWWFrEbstwjUBYEhr5VRGoC+iPDZQucHppCowaIp8b8v92tU1G4X4H3b/Y6zXZxkMsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -6154,15 +6151,15 @@
       "license": "MIT"
     },
     "node_modules/google-auth-library": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.0.tgz",
-      "integrity": "sha512-CmIrSy1bqMQUsPmA9+hcSbAXL80cFhu40cGMUjCaLpNKVzzvi+0uAHq8GNZxkoGYIsTX4ZQ7e4aInAqWxgn4fg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.1.tgz",
+      "integrity": "sha512-VlvZ+QDWng3aPh++0BSQlSJyjn4qgLLTmqylAR3as0dr6YwPkZpHcZAngAFr68TDVCUSQVRTkV73K/D3m7vEIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "gaxios": "^7.0.0",
-        "gcp-metadata": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
         "google-logging-utils": "^1.0.0",
         "gtoken": "^8.0.0",
         "jws": "^4.0.0"
@@ -6567,9 +6564,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-      "integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -6646,7 +6643,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
       "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.4.0",
         "cluster-key-slot": "^1.1.0",
@@ -6667,17 +6663,17 @@
       }
     },
     "node_modules/ioredis-mock": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.0.tgz",
-      "integrity": "sha512-oO6s5xeL3A+EmcmyoEAMxJnwsnXaBfo5IYD2cctsqxLbX9d6dZm67k5nDXAUWMtkIVJJeEbDa4LuFpDowJbvaw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.9.0.tgz",
+      "integrity": "sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ioredis/as-callback": "^3.0.0",
-        "@ioredis/commands": "^1.4.0",
+        "@ioredis/commands": "^1.2.0",
         "fengari": "^0.1.4",
         "fengari-interop": "^0.1.3",
-        "semver": "^7.7.2"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=12.22"
@@ -6782,6 +6778,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7257,7 +7254,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8656,9 +8652,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
+      "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9032,6 +9028,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -9069,7 +9066,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9188,11 +9184,12 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
-      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
@@ -9201,7 +9198,6 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -9698,17 +9694,16 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/requires-port": {
@@ -9721,6 +9716,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -9861,6 +9857,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11"
+      }
+    },
+    "node_modules/rule/node_modules/@tazama-lf/frms-coe-lib": {
+      "version": "6.0.0-postgres.alpha.11",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-postgres.alpha.11/874068342144bced91b445690f929b2fec3ae583",
+      "integrity": "sha512-lEVPcnHqwGXmTQUZhUZTKOZTxvWfW9iAHUUqnPZ5Gy7Z71nzvBcGpyADR2IkLD/12wKXDHbwPhSgQkwUM5pjlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@grpc/grpc-js": "^1.13.4",
+        "@grpc/proto-loader": "~0.7.15",
+        "@types/pg": "^8.15.5",
+        "@types/uuid": "^10.0.0",
+        "dotenv": "^17.2.1",
+        "elastic-apm-node": "^4.14.0",
+        "ioredis": "^5.7.0",
+        "node-cache": "^5.1.2",
+        "pg": "8.16.3",
+        "pino": "^9.9.0",
+        "pino-elasticsearch": "^8.1.0",
+        "protobufjs": "^7.5.4",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/run-parallel": {
@@ -10190,12 +10208,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/slow-redact": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
-      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
-      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
@@ -10694,6 +10706,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11036,7 +11049,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11238,11 +11250,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "author": "Tazama.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11",
+    "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.13",
     "@tazama-lf/frms-coe-startup-lib": "3.0.0-rc.6",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.3",
     "node-cache": "^5.1.2",
     "rule": "npm:@tazama-lf/rule-901@3.0.0-rc.6",
     "ts-node": "^10.9.2",
@@ -35,21 +35,21 @@
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-    "@stylistic/eslint-plugin": "^5.3.1",
+    "@stylistic/eslint-plugin": "^5.5.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.42.0",
-    "@typescript-eslint/parser": "^8.42.0",
-    "eslint": "^9.34.0",
+    "@typescript-eslint/eslint-plugin": "^8.46.1",
+    "@typescript-eslint/parser": "^8.46.1",
+    "eslint": "^9.38.0",
     "eslint-config-love": "^122.0.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "9.1.7",
-    "ioredis-mock": "^8.9.0",
-    "jest": "^30.1.2",
-    "lint-staged": "^16.1.6",
+    "ioredis-mock": "8.9.0",
+    "jest": "^30.2.0",
+    "lint-staged": "^16.2.4",
     "prettier": "^3.6.2",
-    "ts-jest": "^29.4.1",
-    "typescript": "^5.8.3"
+    "ts-jest": "^29.4.5",
+    "typescript": "~5.8.3"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
## What did we change?

Update frms-coe-lib

## Why are we doing this?

Gain access to latest getRuleConfig query with fixed cache key

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
