### PR TITLE
fix: determine outcome

### DIFF
--- a/src/helpers/determineOutcome.ts
+++ b/src/helpers/determineOutcome.ts
@@ -9,7 +9,7 @@ const determineOutcome = (value: number, ruleConfig: RuleConfig, ruleResult: Rul
     const reason = 'Rule processor configuration invalid';
     loggerService.error(reason);
     return {
-      ...ruleResult,
+      ...res,
       reason,
     };
   }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
incorrect rule-result is returned

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
