### PR TITLE
build: bump @tazama-lf deps to rc and update CODEOWNERS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "rule-executer",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rule-executer",
-      "version": "4.0.0-rc.0",
+      "version": "4.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
-        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.1",
+        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
         "dotenv": "^17.2.3",
         "node-cache": "^5.1.2",
         "rule": "npm:@tazama-lf/rule-901@4.0.0-rc.0",
@@ -2081,41 +2081,18 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.0.2-rc.1",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.1/9764af7bef2bcec512ed6bc67f4ea7cb2fc338d2",
-      "integrity": "sha512-0ypHqfDNR7GAFj3+FfUvrSJGNcLoCRmt57i4Rv1vysIiLfuUt/9ApCQS5P4JoWy+hy8NNwCvGC29k1NRcfhAVg==",
+      "version": "3.0.2-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.2/4c73fb8b2186d6cb1ba927d6c6eede58d65e1c1d",
+      "integrity": "sha512-0puBZ+bWUjCxTO/wggn9dHRX5gxHvCXo/Z6w/Mw/ODY5pLqxOzSOv///OVZmgolFQ5s+iUCfDCnpX3tMOiSLoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",
         "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "7.0.2-rc.0",
+        "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "google-auth-library": "^10.2.0",
         "nats": "^2.29.3"
-      }
-    },
-    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "7.0.2-rc.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/7.0.2-rc.0/f2efc50e11c0ce758b7117d9647cf17c43135ddc",
-      "integrity": "sha512-bADpfuxcZavpZf/BUc9AqF2O0QfICP9I86N+yUVrtrpEJHuioqylevBOfom/FboABVL/cxOZrcbbb1XZHziALw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@elastic/ecs-pino-format": "^1.5.0",
-        "@grpc/grpc-js": "^1.13.4",
-        "@grpc/proto-loader": "~0.7.15",
-        "@types/pg": "^8.15.5",
-        "@types/uuid": "^10.0.0",
-        "dotenv": "^17.2.1",
-        "elastic-apm-node": "^4.14.0",
-        "ioredis": "^5.7.0",
-        "node-cache": "^5.1.2",
-        "pg": "8.16.3",
-        "pg-format": "^1.0.4",
-        "pino": "^9.9.0",
-        "pino-elasticsearch": "^8.1.0",
-        "protobufjs": "^7.5.4",
-        "uuid": "^11.1.0"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rule-executer",
-  "version": "4.0.0-rc.0",
+  "version": "4.0.0-rc.1",
   "description": "Tazama Rule Executer for rule processor wrapping",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@tazama-lf/frms-coe-lib": "7.0.2-rc.2",
-    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.1",
+    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.2",
     "dotenv": "^17.2.3",
     "node-cache": "^5.1.2",
     "rule": "npm:@tazama-lf/rule-901@4.0.0-rc.0",


### PR DESCRIPTION
## Summary

Bumps @tazama-lf dependencies to latest rc versions and updates repo housekeeping.

### Dependency updates

| Package | From | To |
|---------|------|----|
| @tazama-lf/frms-coe-startup-lib | 3.0.2-rc.1 | 3.0.2-rc.2 |

### Version bump

4.0.0-rc.0 -> 4.0.0-rc.1

### CI changes

- Removed CHANGELOG.md and VERSION (if present)
- Updated .github/CODEOWNERS: * @tazama-lf/core-codeowners @tazama-lf/community-codeowners