### PR TITLE
fix(dockerfile): migrate ARG GH_TOKEN to BuildKit --mount=type=secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BUILD_IMAGE=node:20-bullseye
@@ -13,9 +14,7 @@ COPY ./src ./src
 COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-
-RUN npm ci --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --ignore-scripts
 RUN npm run build
 
 # Stage 2 (Remove Unneeded Node Modules)
@@ -25,8 +24,7 @@ LABEL stage=pre-prod
 
 COPY package*.json ./
 COPY .npmrc ./
-ARG GH_TOKEN
-RUN npm ci --omit=dev --ignore-scripts
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci --omit=dev --ignore-scripts
 
 # Stage 3 (Run Image - Everything above not included in final build)
 FROM ${RUN_IMAGE} AS run-env


### PR DESCRIPTION
﻿## Summary

Migrates `GH_TOKEN` injection in the `rule-executer` Dockerfile from `ARG GH_TOKEN` (passed via `--build-arg`) to BuildKit `--mount=type=secret`. This fixes broken Docker builds caused by the reusable `package-rule` workflows not passing the token, and removes a credential exposure risk.

## Problem

Two issues with the current `ARG GH_TOKEN` approach:

1. **Regression from reusable workflow migration:** `tazama-lf/workflows` `package-rule.yml` and `package-rule-rc.yml` call `docker build` without `--build-arg GH_TOKEN=...`, so `GH_TOKEN` is empty inside the container - both `npm ci` stages fail to authenticate against GitHub Packages. See tazama-lf/workflows#73.

2. **Credential exposure (OWASP A02):** Docker build-args are recorded in image layer metadata and visible to anyone with pull access via `docker history --no-trunc`.

## Changes

- `Dockerfile`: add `# syntax=docker/dockerfile:1` directive (required for BuildKit extended syntax)
- `Dockerfile`: replace `ARG GH_TOKEN` + `RUN npm ci` with `RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm ci` in both Stage 1 (builder) and Stage 2 (dep-resolver)

## Merge order

This PR must be merged **before** tazama-lf/workflows#73. Switching to `--mount=type=secret` is backwards compatible - if no secret is provided, the env var is simply absent (same behaviour as today). Once the workflows PR is merged, the secret will be injected correctly.

## Related

Consistent with the fix applied to all 11 service repo Dockerfiles during the PR #53 work.

- Closes #385
- Pair PR: tazama-lf/workflows#73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration for improved security and performance during the image build process.

**Note:** This release includes no user-facing changes. Updates are internal to the build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->