### PR TITLE
fix: collapse unexpected rule config fetch error into concise reason (#444)

### DIFF
--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -212,6 +212,34 @@ describe('Logic Service', () => {
       );
     });
 
+    it('should collapse an unexpected getRuleConfig error (e.g. ZodError) to a concise reason ', async () => {
+      const zodLikeError = new Error(
+        'ZodError: [\n  {\n    "expected": "number",\n    "code": "invalid_type",\n    "path": [ "config", "parameters", "maxQueryRange" ],\n    "message": "Invalid input: expected number, received undefined"\n  }\n]',
+      );
+
+      jest.spyOn(databaseManager, 'getRuleConfig').mockImplementationOnce(async (): Promise<RuleConfig> => {
+        throw zodLikeError;
+      });
+
+      const expectedReq = getMockRequest();
+
+      responseSpy = jest.spyOn(server, 'handleResponse').mockImplementationOnce(jest.fn());
+
+      await execute(expectedReq);
+
+      expect(responseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ruleResult: expect.objectContaining({
+            subRuleRef: '.err',
+            reason: 'Error while getting rule configuration',
+          }),
+        }),
+      );
+      // The verbose underlying message must not leak onto the wire.
+      const call = responseSpy.mock.calls[0][0] as { ruleResult: RuleResult };
+      expect(call.ruleResult.reason).not.toContain('ZodError');
+    });
+
     it('should fail if unable to parse - missing properties ', async () => {
       jest.spyOn(databaseManager, 'getRuleConfig').mockRejectedValueOnce(async (): Promise<RuleConfig[][]> => {
         return await Promise.reject('BAD');

--- a/src/controllers/execute.ts
+++ b/src/controllers/execute.ts
@@ -83,10 +83,15 @@ export const execute = async (reqObj: unknown): Promise<void> => {
     spanRuleConfig?.end();
     loggerService.error('Error while getting rule configuration', util.inspect(error), context, configuration.functionName);
     ruleRes.prcgTm = calculateDuration(startTime);
+    // The full error detail is retained in the log above. On the wire we surface the concise,
+    // known guard reasons as-is, but collapse any other failure (e.g. a config validation/DB
+    // error such as a ZodError) to a generic reason rather than leaking the full message.
+    const knownGuardReasons = ['Rule not found in network map', 'Rule processor configuration not retrievable'];
+    const rawReason = (error as Error).message;
     ruleRes = {
       ...ruleRes,
       subRuleRef: '.err',
-      reason: (error as Error).message,
+      reason: knownGuardReasons.includes(rawReason) ? rawReason : 'Error while getting rule configuration',
     };
     const spanHandleResponse = apm.startSpan(`handleResponse.${ruleRes.id}.err`);
     await server.handleResponse({


### PR DESCRIPTION
## What

Collapse an unexpected rule config fetch/validation error into a concise `reason` on the rule result, instead of surfacing the full underlying error message (which for a validation failure is the entire multi-line ZodError JSON blob).

Resolves #444.

## Why

When `getRuleConfig` failed - for example when the stored rule configuration fails the rule stub's Zod validation - the executer copied the raw `error.message` into `ruleResult.reason`. That put a verbose, multi-line ZodError payload on the wire, which is unhelpful to downstream consumers and noisy in results.

## How

In the config-fetch `catch` block of `execute.ts`:

- The two known, already-concise internal guard reasons are surfaced as-is:
  - `Rule not found in network map`
  - `Rule processor configuration not retrievable`
- Any other failure (e.g. a config validation/DB error such as a ZodError) is collapsed to the concise label `Error while getting rule configuration`.
- The full error detail is still logged via `loggerService.error` for diagnostics - nothing is lost from the logs.

## Tests

- Added a regression test asserting an unexpected `getRuleConfig` error (a ZodError-like message) collapses to `Error while getting rule configuration` and does not leak the verbose message onto the wire.
- The two existing tests that assert the concise guard reasons remain green.
- Full unit suite for `logic.service.test.ts`: 12 passed.
- `npm run build` clean; eslint clean.

## Notes

- This is tweak 2 of two console/result cleanups. Tweak 1 (logger `\r\n` mangling) is tracked separately in frms-coe-lib #435 and is intentionally out of scope here.
