### PR TITLE
fix(ci): dispatch rule 901/902 with write-capable token

### DIFF
--- a/.github/workflows/trigger-rules-901-and-902.yml
+++ b/.github/workflows/trigger-rules-901-and-902.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Dispatch to Rule 901
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GH_TOKEN_LIB }}  # PAT with repo scope
+          token: ${{ secrets.GH_TOKEN }}  # needs Contents: write on the target repo to send a repository_dispatch
           repository: tazama-lf/rule-901
           event-type: rule-executer-update  # Custom event type
       - name: Dispatch to Rule 902
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GH_TOKEN_LIB }} # Same PAT
+          token: ${{ secrets.GH_TOKEN }} # same write-capable token
           repository: tazama-lf/rule-902
           event-type: rule-executer-update # Same event type


### PR DESCRIPTION
## What

Point the `repository_dispatch` steps in `trigger-rules-901-and-902.yml` at `secrets.GH_TOKEN` instead of `secrets.GH_TOKEN_LIB`.

## Why

The post-`dev` dispatch job fails with:

```
##[error]Repository not found, OR token has insufficient permissions.
```

`peter-evans/repository-dispatch` sends a `repository_dispatch` event to `tazama-lf/rule-901` and `tazama-lf/rule-902`. That is a **write** operation and requires `Contents: write` on the target repo. The step was using `GH_TOKEN_LIB`, which is the dedicated **read:packages** token - it cannot dispatch, hence the "insufficient permissions" error.

`GH_TOKEN` carries `Contents` write on the rule repos and is the correct token for a cross-repo dispatch. (The automatic `GITHUB_TOKEN` cannot be used here - it is scoped to the current repo only.)

## Change

Both dispatch steps: `token: ${{ secrets.GH_TOKEN_LIB }}` -> `token: ${{ secrets.GH_TOKEN }}`, and the misleading "PAT with repo scope" comments corrected.

## Verification

Merging to `dev` re-triggers the workflow; the two dispatch steps should complete and fire `rule-executer-update` at rule-901 / rule-902.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dispatch credentials to use the current GitHub token, improving reliability of rule-triggered workflows.
  * No changes to the destinations or trigger behavior of the dispatch actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->